### PR TITLE
Reduce heap allocations with better date/time format strings

### DIFF
--- a/src/Hl7.Fhir.Core.Tests/SourceHelperTests.cs
+++ b/src/Hl7.Fhir.Core.Tests/SourceHelperTests.cs
@@ -1,0 +1,115 @@
+﻿using Hl7.Fhir.Serialization;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+
+namespace Hl7.Fhir.Core.Tests
+{
+    [TestClass]
+    public class SourceHelperTests
+    {
+        private const string _validDate = "2012-01-01";
+        private const string _invalidDate = "2012/01/01";
+
+        private const string _validInstant = "2012-01-02T03:04:05Z";
+        private const string _invalidInstant = "2012-01-02T03.04.05Z";
+
+        private const string _validTime = "01:02:03.400";
+        private const string _invalidTime = "01.02.03.400";
+
+        [TestMethodWithCulture("it-IT")]
+        public void IsValidDate_ItalianCulture_UsesFhirSpec()
+        {
+            Assert.IsTrue(SourceHelpers.IsValidDate(_validDate));
+            Assert.IsFalse(SourceHelpers.IsValidDate(_invalidDate));
+        }
+
+        [TestMethodWithCulture("en-US")]
+        public void IsValidDate_USCulture_UsesFhirSpec()
+        {
+            Assert.IsTrue(SourceHelpers.IsValidDate(_validDate));
+            Assert.IsFalse(SourceHelpers.IsValidDate(_invalidDate));
+        }
+
+        [TestMethodWithCulture("ar-DZ")]
+        public void IsValidDate_ArabicAlgerianCulture_UsesFhirSpec()
+        {
+            Assert.IsTrue(SourceHelpers.IsValidDate(_validDate));
+            Assert.IsFalse(SourceHelpers.IsValidDate(_invalidDate));
+        }
+
+        [TestMethodWithCulture("tr-TR")]
+        public void IsValidDate_TurkishCulture_UsesFhirSpec()
+        {
+            Assert.IsTrue(SourceHelpers.IsValidDate(_validDate));
+            Assert.IsFalse(SourceHelpers.IsValidDate(_invalidDate));
+        }
+
+        [TestMethodWithCulture("it-IT")]
+        public void IsValidTime_ItalianCulture_UsesFhirSpec()
+        {
+            Assert.IsTrue(SourceHelpers.IsValidTime(_validTime));
+            Assert.IsFalse(SourceHelpers.IsValidTime(_invalidTime));
+        }
+
+        [TestMethodWithCulture("en-US")]
+        public void IsValidTime_USCulture_UsesFhirSpec()
+        {
+            Assert.IsTrue(SourceHelpers.IsValidTime(_validTime));
+            Assert.IsFalse(SourceHelpers.IsValidTime(_invalidTime));
+        }
+
+        [TestMethodWithCulture("ar-DZ")]
+        public void IsValidTime_ArabicAlgerianCulture_UsesFhirSpec()
+        {
+            Assert.IsTrue(SourceHelpers.IsValidTime(_validTime));
+            Assert.IsFalse(SourceHelpers.IsValidTime(_invalidTime));
+        }
+
+        [TestMethodWithCulture("tr-TR")]
+        public void IsValidTime_TurkishCulture_UsesFhirSpec()
+        {
+            Assert.IsTrue(SourceHelpers.IsValidTime(_validTime));
+            Assert.IsFalse(SourceHelpers.IsValidTime(_invalidTime));
+        }
+
+        [TestMethodWithCulture("it-IT")]
+        public void TryParseFhirInstant_ItalianCulture_UsesFhirSpec()
+        {
+            Assert.IsTrue(SourceHelpers.TryParseFhirInstant(_validInstant, out var instant));
+            Assert.AreEqual(new DateTimeOffset(2012, 1, 2, 3, 4, 5, TimeSpan.Zero), instant);
+
+            Assert.IsFalse(SourceHelpers.TryParseFhirInstant(_invalidInstant, out instant));
+            Assert.AreEqual(default(DateTimeOffset), instant);
+        }
+
+        [TestMethodWithCulture("en-US")]
+        public void TryParseFhirInstant_USCulture_UsesFhirSpec()
+        {
+            Assert.IsTrue(SourceHelpers.TryParseFhirInstant(_validInstant, out var instant));
+            Assert.AreEqual(new DateTimeOffset(2012, 1, 2, 3, 4, 5, TimeSpan.Zero), instant);
+
+            Assert.IsFalse(SourceHelpers.TryParseFhirInstant(_invalidInstant, out instant));
+            Assert.AreEqual(default, instant);
+        }
+
+        [TestMethodWithCulture("ar-DZ")]
+        public void TryParseFhirInstant_ArabicAlgerianCulture_UsesFhirSpec()
+        {
+            Assert.IsTrue(SourceHelpers.TryParseFhirInstant(_validInstant, out var instant));
+            Assert.AreEqual(new DateTimeOffset(2012, 1, 2, 3, 4, 5, TimeSpan.Zero), instant);
+
+            Assert.IsFalse(SourceHelpers.TryParseFhirInstant(_invalidInstant, out instant));
+            Assert.AreEqual(default(DateTimeOffset), instant);
+        }
+
+        [TestMethodWithCulture("tr-TR")]
+        public void TryParseFhirInstant_TurkishCulture_UsesFhirSpec()
+        {
+            Assert.IsTrue(SourceHelpers.TryParseFhirInstant(_validInstant, out var instant));
+            Assert.AreEqual(new DateTimeOffset(2012, 1, 2, 3, 4, 5, TimeSpan.Zero), instant);
+
+            Assert.IsFalse(SourceHelpers.TryParseFhirInstant(_invalidInstant, out instant));
+            Assert.AreEqual(default, instant);
+        }
+    }
+}

--- a/src/Hl7.Fhir.Core.Tests/TestMethodWithCultureAttribute.cs
+++ b/src/Hl7.Fhir.Core.Tests/TestMethodWithCultureAttribute.cs
@@ -1,0 +1,33 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Globalization;
+
+namespace Hl7.Fhir.Core.Tests
+{
+    public class TestMethodWithCultureAttribute : TestMethodAttribute
+    {
+        private readonly CultureInfo _culture;
+
+        public TestMethodWithCultureAttribute(string culture)
+        {
+            _culture = new CultureInfo(culture, false);
+        }
+
+        public override TestResult[] Execute(ITestMethod testMethod)
+        {
+            var originalCulture = System.Threading.Thread.CurrentThread.CurrentCulture;
+            var originalUICulture = System.Threading.Thread.CurrentThread.CurrentUICulture;
+            try
+            {
+                System.Threading.Thread.CurrentThread.CurrentCulture = _culture;
+                System.Threading.Thread.CurrentThread.CurrentUICulture = _culture;
+
+                return base.Execute(testMethod);
+            }
+            finally
+            {
+                System.Threading.Thread.CurrentThread.CurrentCulture = originalCulture;
+                System.Threading.Thread.CurrentThread.CurrentUICulture = originalUICulture;
+            }
+        }
+    }
+}

--- a/src/Hl7.Fhir.Core/Serialization/SourceHelpers.cs
+++ b/src/Hl7.Fhir.Core/Serialization/SourceHelpers.cs
@@ -39,29 +39,29 @@ namespace Hl7.Fhir.Serialization
         private static readonly string[] _dateFormats = new[]
         {
             "yyyy",
-            "yyyy'-'MM",
-            "yyyy'-'MM'-'dd"
+            "yyyy-MM",
+            "yyyy-MM-dd"
         };
 
         private static readonly string[] _utcFormats = new[]
         {
-                "yyyy'-'MM'-'dd'T'HH':'mm'Z'",
-                "yyyy'-'MM'-'dd'T'HH':'mm':'ss'Z'",
-                "yyyy'-'MM'-'dd'T'HH':'mm':'ss'.'FFFFFFF'Z'",
+                "yyyy-MM-ddTHH:mmZ",
+                "yyyy-MM-ddTHH:mm:ssZ",
+                "yyyy-MM-ddTHH:mm:ss.FFFFFFFZ",
         };
 
         private static readonly string[] _timeZoneFormats = new[]
         {
-                "yyyy'-'MM'-'dd'T'HH':'mmzzz",
-                "yyyy'-'MM'-'dd'T'HH':'mm':'sszzz",
-                "yyyy'-'MM'-'dd'T'HH':'mm':'ss'.'FFFFFFFzzz",
+                "yyyy-MM-ddTHH:mmzzz",
+                "yyyy-MM-ddTHH:mm:sszzz",
+                "yyyy-MM-ddTHH:mm:ss.FFFFFFFzzz",
         };
 
         private static readonly string[] _timeFormats = new[]
         {
-                "HH':'mm",
-                "HH':'mm':'ss",
-                "HH':'mm':'ss'.'FFFFFFF",
+                "HH:mm",
+                "HH:mm:ss",
+                "HH:mm:ss.FFFFFFF",
         };
     }
 }


### PR DESCRIPTION
This PR removes the `'` from custom date/time format strings.

`TryParseExact` uses a `StringBulider` for each delimiter literal when it is surrounded by single quotes, which can end up with a lot of strings on the heap. (see https://github.com/microsoft/referencesource/blob/master/mscorlib/system/globalization/datetimeparse.cs#L3808-L3847)

Since we are specifying the invariant culture for each call, the `'` are not needed and we can just use the unescaped delimiter characters.
